### PR TITLE
Fix missing closing brace in CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -94,6 +94,7 @@ body {
 
 .bookmark-item span {
     font-size: 0.9em;
+}
 
 
 /* ... (estilos anteriores, incluindo .bookmark-category.drag-over) ... */


### PR DESCRIPTION
## Summary
- close `.bookmark-item span` rule in `style.css`

## Testing
- `grep -o '{' -n css/style.css | wc -l`
- `grep -o '}' -n css/style.css | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_6882ef3e121c832ab97d4abd07fb8bbb