### PR TITLE
Add icon appearance options

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,9 @@
 /* css/style.css */
 :root {
     --icon-size: 32px;
+    --icon-border-radius: 6px;
+    --icon-border-color: #ddd;
+    --icon-bg-color: #fff;
 }
 body {
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
@@ -74,9 +77,9 @@ body {
 
 .bookmark-item {
     position: relative;
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 6px;
+    background-color: var(--icon-bg-color);
+    border: 1px solid var(--icon-border-color);
+    border-radius: var(--icon-border-radius);
     padding: 8px;
     text-align: center;
     text-decoration: none;
@@ -191,9 +194,9 @@ body {
 /* Ajuste no .bookmark-item para acomodar favicon e nome lado a lado, e o X */
 .bookmark-item {
     position: relative;
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 6px;
+    background-color: var(--icon-bg-color);
+    border: 1px solid var(--icon-border-color);
+    border-radius: var(--icon-border-radius);
     padding: 10px;
     text-decoration: none;
     color: #333;
@@ -335,8 +338,8 @@ body.dark-theme .bookmark-category h2 {
 }
 
 body.dark-theme .bookmark-item {
-    background-color: #333;
-    border-color: #555;
+    background-color: var(--icon-bg-color);
+    border-color: var(--icon-border-color);
     color: #eee;
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -17,6 +17,9 @@ document.addEventListener('DOMContentLoaded', function() {
     ];
     let currentBookmarks = [];
     let iconSize = 32;
+    let iconBorderRadius = 6;
+    let iconBorderColor = '#ddd';
+    let iconBgColor = '#fff';
 
     function applyIconSizeSetting(size) {
         document.documentElement.style.setProperty('--icon-size', `${size}px`);
@@ -27,13 +30,29 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    function applyIconAppearance() {
+        document.documentElement.style.setProperty('--icon-border-radius', `${iconBorderRadius}px`);
+        document.documentElement.style.setProperty('--icon-border-color', iconBorderColor);
+        document.documentElement.style.setProperty('--icon-bg-color', iconBgColor);
+    }
+
     function loadSettings(callback) {
         chrome.storage.local.get(['extensionSettings'], result => {
             const settings = result.extensionSettings || {};
             if (settings.iconSize) {
                 iconSize = settings.iconSize;
             }
+            if (settings.iconBorderRadius !== undefined) {
+                iconBorderRadius = settings.iconBorderRadius;
+            }
+            if (settings.iconBorderColor) {
+                iconBorderColor = settings.iconBorderColor;
+            }
+            if (settings.iconBgColor) {
+                iconBgColor = settings.iconBgColor;
+            }
             applyIconSizeSetting(iconSize);
+            applyIconAppearance();
             if (callback) callback();
         });
     }
@@ -143,6 +162,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 iconSize = newSettings.iconSize;
                 applyIconSizeSetting(iconSize);
             }
+            if (newSettings.iconBorderRadius !== undefined && newSettings.iconBorderRadius !== iconBorderRadius) {
+                iconBorderRadius = newSettings.iconBorderRadius;
+            }
+            if (newSettings.iconBorderColor && newSettings.iconBorderColor !== iconBorderColor) {
+                iconBorderColor = newSettings.iconBorderColor;
+            }
+            if (newSettings.iconBgColor && newSettings.iconBgColor !== iconBgColor) {
+                iconBgColor = newSettings.iconBgColor;
+            }
+            applyIconAppearance();
         }
     });
 });

--- a/js/settings.js
+++ b/js/settings.js
@@ -12,6 +12,10 @@ document.addEventListener('DOMContentLoaded', function() {
     const filterOpacityValue = document.getElementById('filter-opacity-value');
     const iconSize = document.getElementById('icon-size');
     const iconSizeValue = document.getElementById('icon-size-value');
+    const iconBorderRadius = document.getElementById('icon-border-radius');
+    const iconBorderRadiusValue = document.getElementById('icon-border-radius-value');
+    const iconBorderColor = document.getElementById('icon-border-color');
+    const iconBgColor = document.getElementById('icon-bg-color');
     const nameDisplay = document.getElementById('name-display');
     const exportDataBtn = document.getElementById('export-data-btn');
     const importDataBtn = document.getElementById('import-data-btn');
@@ -27,6 +31,9 @@ document.addEventListener('DOMContentLoaded', function() {
         filterColor: "#000000",
         filterOpacity: 0.3,
         iconSize: 32,
+        iconBorderRadius: 6,
+        iconBorderColor: "#ddd",
+        iconBgColor: "#fff",
         nameDisplay: "always"
     };
 
@@ -43,6 +50,10 @@ document.addEventListener('DOMContentLoaded', function() {
             updateOpacityDisplay(settings.filterOpacity);
             iconSize.value = settings.iconSize;
             updateIconSizeDisplay(settings.iconSize);
+            iconBorderRadius.value = settings.iconBorderRadius;
+            updateBorderRadiusDisplay(settings.iconBorderRadius);
+            iconBorderColor.value = settings.iconBorderColor;
+            iconBgColor.value = settings.iconBgColor;
             nameDisplay.value = settings.nameDisplay;
         });
     }
@@ -55,6 +66,9 @@ document.addEventListener('DOMContentLoaded', function() {
             filterColor: filterColor.value,
             filterOpacity: parseFloat(filterOpacity.value),
             iconSize: parseInt(iconSize.value),
+            iconBorderRadius: parseInt(iconBorderRadius.value),
+            iconBorderColor: iconBorderColor.value,
+            iconBgColor: iconBgColor.value,
             nameDisplay: nameDisplay.value
         };
 
@@ -89,6 +103,10 @@ document.addEventListener('DOMContentLoaded', function() {
         iconSizeValue.textContent = `${value}px`;
     }
 
+    function updateBorderRadiusDisplay(value) {
+        iconBorderRadiusValue.textContent = `${value}px`;
+    }
+
     // Event listeners para atualizar displays
     wallpaperFrequency.addEventListener('input', function() {
         updateFrequencyDisplay(this.value);
@@ -100,6 +118,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     iconSize.addEventListener('input', function() {
         updateIconSizeDisplay(this.value);
+    });
+
+    iconBorderRadius.addEventListener('input', function() {
+        updateBorderRadiusDisplay(this.value);
     });
 
     // Exportar dados

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Página Inicial Personalizada",
   "version": "0.1.0",
-  "description": "Uma página inicial personalizada para otimizar o acesso a bookmarks e oferecer uma experiência visual única. 2025-07-25T15:07:46.705Z work",
+  "description": "Uma página inicial personalizada para otimizar o acesso a bookmarks e oferecer uma experiência visual única. 2025-07-25T15:07:46.705Z work 2025-07-25T16:27:56.485Z work",
   "chrome_url_overrides": {
     "newtab": "newtab.html"
   },

--- a/settings.html
+++ b/settings.html
@@ -118,6 +118,19 @@
                     <option value="hover">Ao Passar o Mouse</option>
                 </select>
             </div>
+            <div class="setting-item">
+                <label for="icon-border-radius">Arredondamento do Ícone:</label>
+                <input type="range" id="icon-border-radius" min="0" max="32" step="1" value="6">
+                <span id="icon-border-radius-value">6px</span>
+            </div>
+            <div class="setting-item">
+                <label for="icon-border-color">Cor da Borda:</label>
+                <input type="color" id="icon-border-color" value="#dddddd">
+            </div>
+            <div class="setting-item">
+                <label for="icon-bg-color">Cor de Fundo do Ícone:</label>
+                <input type="color" id="icon-bg-color" value="#ffffff">
+            </div>
         </div>
 
         <div class="setting-section">


### PR DESCRIPTION
## Summary
- allow customizing icon border radius, border color and background color
- apply new settings on newtab icons

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883ac8ac0ec832ab00fb83e01bd9998