### PR TITLE
Support hiding bookmark names

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -192,6 +192,18 @@ body {
     white-space: nowrap;
 }
 
+.bookmark-item.name-hidden .bookmark-name {
+    display: none;
+}
+
+.bookmark-item.name-hover .bookmark-name {
+    opacity: 0;
+}
+
+.bookmark-item.name-hover:hover .bookmark-name {
+    opacity: 1;
+}
+
 /* Ajuste no .bookmark-item para acomodar favicon e nome lado a lado, e o X */
 .bookmark-item {
     position: relative;

--- a/js/script.js
+++ b/js/script.js
@@ -21,6 +21,7 @@ document.addEventListener('DOMContentLoaded', function() {
     let iconBorderColor = '#ddd';
     let iconBgColor = '#fff';
     let iconSpacing = 8;
+    let nameDisplay = 'always';
 
     function applyIconSizeSetting(size) {
         document.documentElement.style.setProperty('--icon-size', `${size}px`);
@@ -41,6 +42,17 @@ document.addEventListener('DOMContentLoaded', function() {
         document.documentElement.style.setProperty('--icon-spacing', `${spacing}px`);
     }
 
+    function updateNameDisplayClasses() {
+        document.querySelectorAll('.bookmark-item').forEach(item => {
+            item.classList.remove('name-hidden', 'name-hover');
+            if (nameDisplay === 'never') {
+                item.classList.add('name-hidden');
+            } else if (nameDisplay === 'hover') {
+                item.classList.add('name-hover');
+            }
+        });
+    }
+
     function loadSettings(callback) {
         chrome.storage.local.get(['extensionSettings'], result => {
             const settings = result.extensionSettings || {};
@@ -59,9 +71,13 @@ document.addEventListener('DOMContentLoaded', function() {
             if (settings.iconSpacing !== undefined) {
                 iconSpacing = settings.iconSpacing;
             }
+            if (settings.nameDisplay) {
+                nameDisplay = settings.nameDisplay;
+            }
             applyIconSizeSetting(iconSize);
             applyIconAppearance();
             applyIconSpacingSetting(iconSpacing);
+            updateNameDisplayClasses();
             if (callback) callback();
         });
     }
@@ -88,6 +104,11 @@ document.addEventListener('DOMContentLoaded', function() {
             category.links.forEach(link => {
                 const bookmarkItem = document.createElement('a');
                 bookmarkItem.className = 'bookmark-item';
+                if (nameDisplay === 'never') {
+                    bookmarkItem.classList.add('name-hidden');
+                } else if (nameDisplay === 'hover') {
+                    bookmarkItem.classList.add('name-hover');
+                }
                 bookmarkItem.href = link.url;
                 bookmarkItem.target = '_blank';
 
@@ -124,6 +145,7 @@ document.addEventListener('DOMContentLoaded', function() {
             });
             contentArea.appendChild(categoryDiv);
         });
+        updateNameDisplayClasses();
     }
 
     function initialize() {
@@ -183,6 +205,10 @@ document.addEventListener('DOMContentLoaded', function() {
             if (newSettings.iconSpacing !== undefined && newSettings.iconSpacing !== iconSpacing) {
                 iconSpacing = newSettings.iconSpacing;
                 applyIconSpacingSetting(iconSpacing);
+            }
+            if (newSettings.nameDisplay && newSettings.nameDisplay !== nameDisplay) {
+                nameDisplay = newSettings.nameDisplay;
+                updateNameDisplayClasses();
             }
             applyIconAppearance();
         }

--- a/js/settings.js
+++ b/js/settings.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', function() {
             updateBorderRadiusDisplay(settings.iconBorderRadius);
             iconBorderColor.value = settings.iconBorderColor;
             iconBgColor.value = settings.iconBgColor;
-            nameDisplay.value = settings.nameDisplay;
+            nameDisplay.value = settings.nameDisplay !== undefined ? settings.nameDisplay : defaultSettings.nameDisplay;
         });
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Página Inicial Personalizada",
   "version": "0.1.0",
-  "description": "Uma página inicial personalizada para otimizar o acesso a bookmarks e oferecer uma experiência visual única. 2025-07-25T15:07:46.705Z work 2025-07-25T16:27:56.485Z work",
+  "description": "Uma página inicial personalizada para otimizar o acesso a bookmarks e oferecer uma experiência visual única. 2025-07-25T15:07:46.705Z work 2025-07-25T16:27:56.485Z work 2025-07-25T21:24:45.778Z work",
   "chrome_url_overrides": {
     "newtab": "newtab.html"
   },

--- a/settings.html
+++ b/settings.html
@@ -121,6 +121,7 @@
                 <select id="name-display">
                     <option value="always">Sempre Visível</option>
                     <option value="hover">Ao Passar o Mouse</option>
+                    <option value="never">Nunca Visível</option>
                 </select>
             </div>
             <div class="setting-item">


### PR DESCRIPTION
## Summary
- add new `Nunca Visível` option in the name display dropdown
- keep default setting and read from storage safely
- allow script to hide bookmark names based on setting
- update bookmarks when option changes
- add CSS classes for hiding/hover effects

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883f5843a9c832ab855218d0324e5e5