### PR TITLE
Add adjustable bookmark width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,6 +5,7 @@
     --icon-border-color: #ddd;
     --icon-bg-color: #fff;
     --icon-spacing: 8px;
+    --bookmark-min-width: 100px;
 }
 body {
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
@@ -72,8 +73,8 @@ body {
 
 .bookmarks-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); /* Grid responsivo */
-    gap: var(--icon-spacing); /* Espaçamento entre os ícones */
+    grid-template-columns: repeat(auto-fill, minmax(var(--bookmark-min-width), 1fr));
+    gap: var(--icon-spacing);
 }
 
 .bookmark-item {

--- a/js/script.js
+++ b/js/script.js
@@ -21,6 +21,7 @@ document.addEventListener('DOMContentLoaded', function() {
     let iconBorderColor = '#ddd';
     let iconBgColor = '#fff';
     let iconSpacing = 8;
+    let bookmarkMinWidth = 100;
 
     function applyIconSizeSetting(size) {
         document.documentElement.style.setProperty('--icon-size', `${size}px`);
@@ -41,6 +42,10 @@ document.addEventListener('DOMContentLoaded', function() {
         document.documentElement.style.setProperty('--icon-spacing', `${spacing}px`);
     }
 
+    function applyBookmarkMinWidthSetting(width) {
+        document.documentElement.style.setProperty('--bookmark-min-width', `${width}px`);
+    }
+
     function loadSettings(callback) {
         chrome.storage.local.get(['extensionSettings'], result => {
             const settings = result.extensionSettings || {};
@@ -59,9 +64,13 @@ document.addEventListener('DOMContentLoaded', function() {
             if (settings.iconSpacing !== undefined) {
                 iconSpacing = settings.iconSpacing;
             }
+            if (settings.bookmarkMinWidth !== undefined) {
+                bookmarkMinWidth = settings.bookmarkMinWidth;
+            }
             applyIconSizeSetting(iconSize);
             applyIconAppearance();
             applyIconSpacingSetting(iconSpacing);
+            applyBookmarkMinWidthSetting(bookmarkMinWidth);
             if (callback) callback();
         });
     }
@@ -183,6 +192,10 @@ document.addEventListener('DOMContentLoaded', function() {
             if (newSettings.iconSpacing !== undefined && newSettings.iconSpacing !== iconSpacing) {
                 iconSpacing = newSettings.iconSpacing;
                 applyIconSpacingSetting(iconSpacing);
+            }
+            if (newSettings.bookmarkMinWidth !== undefined && newSettings.bookmarkMinWidth !== bookmarkMinWidth) {
+                bookmarkMinWidth = newSettings.bookmarkMinWidth;
+                applyBookmarkMinWidthSetting(bookmarkMinWidth);
             }
             applyIconAppearance();
         }

--- a/js/settings.js
+++ b/js/settings.js
@@ -14,6 +14,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const iconSizeValue = document.getElementById('icon-size-value');
     const iconSpacing = document.getElementById('icon-spacing');
     const iconSpacingValue = document.getElementById('icon-spacing-value');
+    const bookmarkMinWidth = document.getElementById('bookmark-min-width');
+    const bookmarkMinWidthValue = document.getElementById('bookmark-min-width-value');
     const iconBorderRadius = document.getElementById('icon-border-radius');
     const iconBorderRadiusValue = document.getElementById('icon-border-radius-value');
     const iconBorderColor = document.getElementById('icon-border-color');
@@ -34,6 +36,7 @@ document.addEventListener('DOMContentLoaded', function() {
         filterOpacity: 0.3,
         iconSize: 32,
         iconSpacing: 8,
+        bookmarkMinWidth: 100,
         iconBorderRadius: 6,
         iconBorderColor: "#ddd",
         iconBgColor: "#fff",
@@ -55,6 +58,8 @@ document.addEventListener('DOMContentLoaded', function() {
             updateIconSizeDisplay(settings.iconSize);
             iconSpacing.value = settings.iconSpacing;
             updateIconSpacingDisplay(settings.iconSpacing);
+            bookmarkMinWidth.value = settings.bookmarkMinWidth;
+            updateBookmarkMinWidthDisplay(settings.bookmarkMinWidth);
             iconBorderRadius.value = settings.iconBorderRadius;
             updateBorderRadiusDisplay(settings.iconBorderRadius);
             iconBorderColor.value = settings.iconBorderColor;
@@ -72,6 +77,7 @@ document.addEventListener('DOMContentLoaded', function() {
             filterOpacity: parseFloat(filterOpacity.value),
             iconSize: parseInt(iconSize.value),
             iconSpacing: parseInt(iconSpacing.value),
+            bookmarkMinWidth: parseInt(bookmarkMinWidth.value),
             iconBorderRadius: parseInt(iconBorderRadius.value),
             iconBorderColor: iconBorderColor.value,
             iconBgColor: iconBgColor.value,
@@ -113,6 +119,10 @@ document.addEventListener('DOMContentLoaded', function() {
         iconSpacingValue.textContent = `${value}px`;
     }
 
+    function updateBookmarkMinWidthDisplay(value) {
+        bookmarkMinWidthValue.textContent = `${value}px`;
+    }
+
     function updateBorderRadiusDisplay(value) {
         iconBorderRadiusValue.textContent = `${value}px`;
     }
@@ -132,6 +142,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     iconSpacing.addEventListener('input', function() {
         updateIconSpacingDisplay(this.value);
+    });
+
+    bookmarkMinWidth.addEventListener('input', function() {
+        updateBookmarkMinWidthDisplay(this.value);
     });
 
     iconBorderRadius.addEventListener('input', function() {

--- a/settings.html
+++ b/settings.html
@@ -117,6 +117,11 @@
                 <span id="icon-spacing-value">8px</span>
             </div>
             <div class="setting-item">
+                <label for="bookmark-min-width">Largura Mínima do Bookmark:</label>
+                <input type="range" id="bookmark-min-width" min="80" max="120" step="4" value="100">
+                <span id="bookmark-min-width-value">100px</span>
+            </div>
+            <div class="setting-item">
                 <label for="name-display">Exibição do Nome:</label>
                 <select id="name-display">
                     <option value="always">Sempre Visível</option>


### PR DESCRIPTION
## Summary
- add `--bookmark-min-width` CSS variable and use in grid layout
- expose bookmark width slider in settings page
- persist bookmark width via settings storage
- apply bookmark width setting in script

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883f590e388832abe12a920da212b01