### PR TITLE
refactor: split settings and bookmark rendering

### DIFF
--- a/js/bookmark-renderer.js
+++ b/js/bookmark-renderer.js
@@ -1,0 +1,57 @@
+import { handleDeleteBookmark } from './modules.js';
+
+export function renderBookmarks(bookmarks, contentArea, iconSize) {
+    contentArea.innerHTML = '';
+    if (!bookmarks || bookmarks.length === 0) return;
+
+    bookmarks.forEach(category => {
+        const categoryDiv = document.createElement('div');
+        categoryDiv.className = 'bookmark-category';
+
+        const categoryTitle = document.createElement('h2');
+        categoryTitle.textContent = category.name;
+        categoryDiv.appendChild(categoryTitle);
+
+        const gridDiv = document.createElement('div');
+        gridDiv.className = 'bookmarks-grid';
+        categoryDiv.appendChild(gridDiv);
+
+        category.links.forEach(link => {
+            const bookmarkItem = document.createElement('a');
+            bookmarkItem.className = 'bookmark-item';
+            bookmarkItem.href = link.url;
+            bookmarkItem.target = '_blank';
+
+            const deleteBtn = document.createElement('span');
+            deleteBtn.className = 'delete-bookmark-btn';
+            deleteBtn.innerHTML = '&times;';
+
+            deleteBtn.addEventListener('click', event => {
+                event.preventDefault();
+                event.stopPropagation();
+                handleDeleteBookmark(
+                    link.url,
+                    category.name,
+                    bookmarks,
+                    updated => renderBookmarks(updated, contentArea, iconSize)
+                );
+            });
+
+            const favicon = document.createElement('img');
+            favicon.className = 'bookmark-favicon';
+            favicon.dataset.url = link.url;
+            favicon.src = `https://www.google.com/s2/favicons?domain=${link.url}&sz=${iconSize}`;
+            favicon.alt = '';
+
+            const bookmarkName = document.createElement('span');
+            bookmarkName.className = 'bookmark-name';
+            bookmarkName.textContent = link.name;
+
+            bookmarkItem.appendChild(favicon);
+            bookmarkItem.appendChild(bookmarkName);
+            bookmarkItem.appendChild(deleteBtn);
+            gridDiv.appendChild(bookmarkItem);
+        });
+        contentArea.appendChild(categoryDiv);
+    });
+}

--- a/js/script.js
+++ b/js/script.js
@@ -1,180 +1,58 @@
 // js/script.js (versão final limpa)
-import { loadBookmarksFromChrome, addBookmarkToChrome, removeBookmarkFromChrome, applyTheme, toggleTheme, updateClock, updateDate, updateCalendar, handleDeleteBookmark } from './modules.js';
+import {
+    loadBookmarksFromChrome,
+    addBookmarkToChrome,
+    applyTheme,
+    toggleTheme,
+    updateClock,
+    updateDate,
+    updateCalendar
+} from './modules.js';
+import {
+    loadSettings,
+    applyIconSizeSetting,
+    applyIconAppearance,
+    applyIconSpacingSetting,
+    applyBookmarkMinWidthSetting,
+    applyIconGapSetting,
+    applyBookmarkFontSettings
+} from './settings-handlers.js';
+import { renderBookmarks } from './bookmark-renderer.js';
 
 document.addEventListener('DOMContentLoaded', function() {
     // ---- CONSTANTES E VARIÁVEIS ----
     const contentArea = document.getElementById('content-area');
-    const analogClockPlaceholder = document.getElementById("analog-clock-placeholder");
-    const datePlaceholder = document.getElementById("date-placeholder");
-    const calendarPlaceholder = document.getElementById("calendar-placeholder");
-    const themeToggleBtn = document.getElementById("theme-toggle-btn");
-    const settingsBtn = document.getElementById("settings-btn");
+    const analogClockPlaceholder = document.getElementById('analog-clock-placeholder');
+    const datePlaceholder = document.getElementById('date-placeholder');
+    const calendarPlaceholder = document.getElementById('calendar-placeholder');
+    const themeToggleBtn = document.getElementById('theme-toggle-btn');
+    const settingsBtn = document.getElementById('settings-btn');
 
     const defaultBookmarkCategories = [
-        { name: "IA", links: [{ name: "ChatGPT", url: "https://chat.openai.com/" }, { name: "Gemini", url: "https://gemini.google.com/" }] },
-        { name: "News", links: [{ name: "Google News", url: "https://news.google.com/" }] },
-        { name: "Ferramentas", links: [{ name: "Photopea", url: "https://www.photopea.com/" }] }
+        { name: 'IA', links: [{ name: 'ChatGPT', url: 'https://chat.openai.com/' }, { name: 'Gemini', url: 'https://gemini.google.com/' }] },
+        { name: 'News', links: [{ name: 'Google News', url: 'https://news.google.com/' }] },
+        { name: 'Ferramentas', links: [{ name: 'Photopea', url: 'https://www.photopea.com/' }] }
     ];
     let currentBookmarks = [];
-    let iconSize = 32;
-    let iconBorderRadius = 6;
-    let iconBorderColor = '#ddd';
-    let iconBgColor = '#fff';
-    let iconSpacing = 8; // padding inside each bookmark
-    let iconGap = 8; // space between bookmark items
-    let bookmarkFontFamily = 'sans-serif';
-    let bookmarkFontSize = 14;
-    let bookmarkFontColor = '#333333';
-    let bookmarkMinWidth = 100;
+    const settingsState = {
+        iconSize: 32,
+        iconBorderRadius: 6,
+        iconBorderColor: '#ddd',
+        iconBgColor: '#fff',
+        iconSpacing: 8,
+        iconGap: 8,
+        bookmarkFontFamily: 'sans-serif',
+        bookmarkFontSize: 14,
+        bookmarkFontColor: '#333333',
+        bookmarkMinWidth: 100
+    };
 
-    function applyIconSizeSetting(size) {
-        document.documentElement.style.setProperty('--icon-size', `${size}px`);
-        document.querySelectorAll('.bookmark-favicon').forEach(img => {
-            if (img.dataset.url) {
-                img.src = `https://www.google.com/s2/favicons?domain=${img.dataset.url}&sz=${size}`;
-            }
-        });
-    }
-
-    function applyIconAppearance() {
-        document.documentElement.style.setProperty('--icon-border-radius', `${iconBorderRadius}px`);
-        document.documentElement.style.setProperty('--icon-border-color', iconBorderColor);
-        document.documentElement.style.setProperty('--icon-bg-color', iconBgColor);
-    }
-
-    function applyIconSpacingSetting(spacing) {
-        document.documentElement.style.setProperty('--icon-spacing', `${spacing}px`);
-    }
-
-    function applyBookmarkMinWidthSetting(width) {
-        document.documentElement.style.setProperty('--bookmark-min-width', `${width}px`);
-    }
-
-    function applyIconGapSetting(gap) {
-        document.documentElement.style.setProperty('--icon-gap', `${gap}px`);
-    }
-
-    function applyBookmarkFontSettings() {
-        document.documentElement.style.setProperty('--bookmark-font-family', bookmarkFontFamily);
-        document.documentElement.style.setProperty('--bookmark-font-size', `${bookmarkFontSize}px`);
-        document.documentElement.style.setProperty('--bookmark-font-color', bookmarkFontColor);
-    }
-
-    function loadSettings(callback) {
-        chrome.storage.local.get(['extensionSettings'], result => {
-            const settings = result.extensionSettings || {};
-            if (settings.iconSize) {
-                iconSize = settings.iconSize;
-            }
-            if (settings.iconBorderRadius !== undefined) {
-                iconBorderRadius = settings.iconBorderRadius;
-            }
-            if (settings.iconBorderColor) {
-                iconBorderColor = settings.iconBorderColor;
-            }
-            if (settings.iconBgColor) {
-                iconBgColor = settings.iconBgColor;
-            }
-            if (settings.iconSpacing !== undefined) {
-                iconSpacing = settings.iconSpacing;
-            }
-            if (settings.iconGap !== undefined) {
-                iconGap = settings.iconGap;
-            } else {
-                iconGap = iconSpacing;
-            }
-
-            if (settings.bookmarkFontFamily) {
-                bookmarkFontFamily = settings.bookmarkFontFamily;
-            }
-            if (settings.bookmarkFontSize !== undefined) {
-                bookmarkFontSize = settings.bookmarkFontSize;
-            }
-            if (settings.bookmarkFontColor) {
-                bookmarkFontColor = settings.bookmarkFontColor;
-            }
-
-            if (settings.bookmarkMinWidth !== undefined) {
-                bookmarkMinWidth = settings.bookmarkMinWidth;
-            }
-
-            applyIconSizeSetting(iconSize);
-            applyIconAppearance();
-            applyIconSpacingSetting(iconSpacing);
-            applyIconGapSetting(iconGap);
-            applyBookmarkFontSettings();
-            applyBookmarkMinWidthSetting(bookmarkMinWidth);
-
-
-            if (callback) callback();
-        });
-    }
-
-    // ---- FUNÇÕES PRINCIPAIS ----
-
-    function renderBookmarks(bookmarks) {
-        contentArea.innerHTML = '';
-
-        if (!bookmarks || bookmarks.length === 0) return;
-
-        bookmarks.forEach(category => {
-            const categoryDiv = document.createElement('div');
-            categoryDiv.className = 'bookmark-category';
-
-            const categoryTitle = document.createElement('h2');
-            categoryTitle.textContent = category.name;
-            categoryDiv.appendChild(categoryTitle);
-
-            const gridDiv = document.createElement('div');
-            gridDiv.className = 'bookmarks-grid';
-            categoryDiv.appendChild(gridDiv);
-
-            category.links.forEach(link => {
-                const bookmarkItem = document.createElement('a');
-                bookmarkItem.className = 'bookmark-item';
-                bookmarkItem.href = link.url;
-                bookmarkItem.target = '_blank';
-
-                const deleteBtn = document.createElement('span');
-                deleteBtn.className = 'delete-bookmark-btn';
-                deleteBtn.innerHTML = '&times;'; // Símbolo 'X'
-
-                deleteBtn.addEventListener('click', function(event) {
-                    // Previne que o clique no 'X' também abra o link do bookmark
-                    event.preventDefault();
-                    event.stopPropagation();
-
-                    // Chama a função que você já tem em modules.js
-                    // mas agora passando os parâmetros corretos
-                    handleDeleteBookmark(link.url, category.name, currentBookmarks, renderBookmarks);
-                });
-
-
-
-                const favicon = document.createElement('img');
-                favicon.className = 'bookmark-favicon';
-                favicon.dataset.url = link.url;
-                favicon.src = `https://www.google.com/s2/favicons?domain=${link.url}&sz=${iconSize}`;
-                favicon.alt = '';
-
-                const bookmarkName = document.createElement('span');
-                bookmarkName.className = 'bookmark-name';
-                bookmarkName.textContent = link.name;
-
-                bookmarkItem.appendChild(favicon);
-                bookmarkItem.appendChild(bookmarkName);
-                bookmarkItem.appendChild(deleteBtn);
-                gridDiv.appendChild(bookmarkItem);
-            });
-            contentArea.appendChild(categoryDiv);
-        });
-    }
-
+    // ---- FUNÇÃO PRINCIPAL ----
     function initialize() {
         loadBookmarksFromChrome(bookmarks => {
             if (bookmarks && bookmarks.length > 0) {
                 currentBookmarks = bookmarks;
-                renderBookmarks(currentBookmarks);
+                renderBookmarks(currentBookmarks, contentArea, settingsState.iconSize);
             } else {
                 currentBookmarks = defaultBookmarkCategories;
                 const tasks = [];
@@ -183,14 +61,14 @@ document.addEventListener('DOMContentLoaded', function() {
                         tasks.push(new Promise(res => addBookmarkToChrome(cat.name, link, res)));
                     });
                 });
-                Promise.all(tasks).then(() => renderBookmarks(currentBookmarks));
+                Promise.all(tasks).then(() => renderBookmarks(currentBookmarks, contentArea, settingsState.iconSize));
             }
         });
 
         // Inicialização de outros componentes
-        chrome.storage.local.get(["theme"], result => applyTheme(result.theme || "light"));
-        if (themeToggleBtn) themeToggleBtn.addEventListener("click", toggleTheme);
-        if (settingsBtn) settingsBtn.addEventListener("click", () => chrome.tabs.create({ url: chrome.runtime.getURL("settings.html") }));
+        chrome.storage.local.get(['theme'], result => applyTheme(result.theme || 'light'));
+        if (themeToggleBtn) themeToggleBtn.addEventListener('click', toggleTheme);
+        if (settingsBtn) settingsBtn.addEventListener('click', () => chrome.tabs.create({ url: chrome.runtime.getURL('settings.html') }));
         if (analogClockPlaceholder) {
             updateClock(analogClockPlaceholder);
             setInterval(() => updateClock(analogClockPlaceholder), 1000);
@@ -206,50 +84,54 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // ---- PONTO DE ENTRADA ----
-    loadSettings(initialize);
+    loadSettings(settingsState, initialize);
 
     chrome.storage.onChanged.addListener((changes, area) => {
         if (area === 'local' && changes.extensionSettings) {
             const newSettings = changes.extensionSettings.newValue || {};
-            if (newSettings.iconSize && newSettings.iconSize !== iconSize) {
-                iconSize = newSettings.iconSize;
-                applyIconSizeSetting(iconSize);
+            if (newSettings.iconSize && newSettings.iconSize !== settingsState.iconSize) {
+                settingsState.iconSize = newSettings.iconSize;
+                applyIconSizeSetting(settingsState.iconSize);
             }
-            if (newSettings.iconBorderRadius !== undefined && newSettings.iconBorderRadius !== iconBorderRadius) {
-                iconBorderRadius = newSettings.iconBorderRadius;
+            if (newSettings.iconBorderRadius !== undefined && newSettings.iconBorderRadius !== settingsState.iconBorderRadius) {
+                settingsState.iconBorderRadius = newSettings.iconBorderRadius;
             }
-            if (newSettings.iconBorderColor && newSettings.iconBorderColor !== iconBorderColor) {
-                iconBorderColor = newSettings.iconBorderColor;
+            if (newSettings.iconBorderColor && newSettings.iconBorderColor !== settingsState.iconBorderColor) {
+                settingsState.iconBorderColor = newSettings.iconBorderColor;
             }
-            if (newSettings.iconBgColor && newSettings.iconBgColor !== iconBgColor) {
-                iconBgColor = newSettings.iconBgColor;
+            if (newSettings.iconBgColor && newSettings.iconBgColor !== settingsState.iconBgColor) {
+                settingsState.iconBgColor = newSettings.iconBgColor;
             }
-            if (newSettings.iconSpacing !== undefined && newSettings.iconSpacing !== iconSpacing) {
-                iconSpacing = newSettings.iconSpacing;
-                applyIconSpacingSetting(iconSpacing);
+            if (newSettings.iconSpacing !== undefined && newSettings.iconSpacing !== settingsState.iconSpacing) {
+                settingsState.iconSpacing = newSettings.iconSpacing;
+                applyIconSpacingSetting(settingsState.iconSpacing);
             }
-            if (newSettings.iconGap !== undefined && newSettings.iconGap !== iconGap) {
-                iconGap = newSettings.iconGap;
-                applyIconGapSetting(iconGap);
-            }
-
-            if (newSettings.bookmarkFontFamily && newSettings.bookmarkFontFamily !== bookmarkFontFamily) {
-                bookmarkFontFamily = newSettings.bookmarkFontFamily;
-            }
-            if (newSettings.bookmarkFontSize !== undefined && newSettings.bookmarkFontSize !== bookmarkFontSize) {
-                bookmarkFontSize = newSettings.bookmarkFontSize;
-            }
-            if (newSettings.bookmarkFontColor && newSettings.bookmarkFontColor !== bookmarkFontColor) {
-                bookmarkFontColor = newSettings.bookmarkFontColor;
+            if (newSettings.iconGap !== undefined && newSettings.iconGap !== settingsState.iconGap) {
+                settingsState.iconGap = newSettings.iconGap;
+                applyIconGapSetting(settingsState.iconGap);
             }
 
-            if (newSettings.bookmarkMinWidth !== undefined && newSettings.bookmarkMinWidth !== bookmarkMinWidth) {
-                bookmarkMinWidth = newSettings.bookmarkMinWidth;
-                applyBookmarkMinWidthSetting(bookmarkMinWidth);
+            if (newSettings.bookmarkFontFamily && newSettings.bookmarkFontFamily !== settingsState.bookmarkFontFamily) {
+                settingsState.bookmarkFontFamily = newSettings.bookmarkFontFamily;
+            }
+            if (newSettings.bookmarkFontSize !== undefined && newSettings.bookmarkFontSize !== settingsState.bookmarkFontSize) {
+                settingsState.bookmarkFontSize = newSettings.bookmarkFontSize;
+            }
+            if (newSettings.bookmarkFontColor && newSettings.bookmarkFontColor !== settingsState.bookmarkFontColor) {
+                settingsState.bookmarkFontColor = newSettings.bookmarkFontColor;
             }
 
-            applyIconAppearance();
-            applyBookmarkFontSettings();
+            if (newSettings.bookmarkMinWidth !== undefined && newSettings.bookmarkMinWidth !== settingsState.bookmarkMinWidth) {
+                settingsState.bookmarkMinWidth = newSettings.bookmarkMinWidth;
+                applyBookmarkMinWidthSetting(settingsState.bookmarkMinWidth);
+            }
+
+            applyIconAppearance(settingsState.iconBorderRadius, settingsState.iconBorderColor, settingsState.iconBgColor);
+            applyBookmarkFontSettings(
+                settingsState.bookmarkFontFamily,
+                settingsState.bookmarkFontSize,
+                settingsState.bookmarkFontColor
+            );
         }
     });
 });

--- a/js/settings-handlers.js
+++ b/js/settings-handlers.js
@@ -1,0 +1,81 @@
+export function applyIconSizeSetting(size) {
+    document.documentElement.style.setProperty('--icon-size', `${size}px`);
+    document.querySelectorAll('.bookmark-favicon').forEach(img => {
+        if (img.dataset.url) {
+            img.src = `https://www.google.com/s2/favicons?domain=${img.dataset.url}&sz=${size}`;
+        }
+    });
+}
+
+export function applyIconAppearance(borderRadius, borderColor, bgColor) {
+    document.documentElement.style.setProperty('--icon-border-radius', `${borderRadius}px`);
+    document.documentElement.style.setProperty('--icon-border-color', borderColor);
+    document.documentElement.style.setProperty('--icon-bg-color', bgColor);
+}
+
+export function applyIconSpacingSetting(spacing) {
+    document.documentElement.style.setProperty('--icon-spacing', `${spacing}px`);
+}
+
+export function applyBookmarkMinWidthSetting(width) {
+    document.documentElement.style.setProperty('--bookmark-min-width', `${width}px`);
+}
+
+export function applyIconGapSetting(gap) {
+    document.documentElement.style.setProperty('--icon-gap', `${gap}px`);
+}
+
+export function applyBookmarkFontSettings(fontFamily, fontSize, fontColor) {
+    document.documentElement.style.setProperty('--bookmark-font-family', fontFamily);
+    document.documentElement.style.setProperty('--bookmark-font-size', `${fontSize}px`);
+    document.documentElement.style.setProperty('--bookmark-font-color', fontColor);
+}
+
+export function loadSettings(state, callback) {
+    chrome.storage.local.get(['extensionSettings'], result => {
+        const settings = result.extensionSettings || {};
+        if (settings.iconSize) {
+            state.iconSize = settings.iconSize;
+        }
+        if (settings.iconBorderRadius !== undefined) {
+            state.iconBorderRadius = settings.iconBorderRadius;
+        }
+        if (settings.iconBorderColor) {
+            state.iconBorderColor = settings.iconBorderColor;
+        }
+        if (settings.iconBgColor) {
+            state.iconBgColor = settings.iconBgColor;
+        }
+        if (settings.iconSpacing !== undefined) {
+            state.iconSpacing = settings.iconSpacing;
+        }
+        if (settings.iconGap !== undefined) {
+            state.iconGap = settings.iconGap;
+        } else {
+            state.iconGap = state.iconSpacing;
+        }
+
+        if (settings.bookmarkFontFamily) {
+            state.bookmarkFontFamily = settings.bookmarkFontFamily;
+        }
+        if (settings.bookmarkFontSize !== undefined) {
+            state.bookmarkFontSize = settings.bookmarkFontSize;
+        }
+        if (settings.bookmarkFontColor) {
+            state.bookmarkFontColor = settings.bookmarkFontColor;
+        }
+
+        if (settings.bookmarkMinWidth !== undefined) {
+            state.bookmarkMinWidth = settings.bookmarkMinWidth;
+        }
+
+        applyIconSizeSetting(state.iconSize);
+        applyIconAppearance(state.iconBorderRadius, state.iconBorderColor, state.iconBgColor);
+        applyIconSpacingSetting(state.iconSpacing);
+        applyIconGapSetting(state.iconGap);
+        applyBookmarkFontSettings(state.bookmarkFontFamily, state.bookmarkFontSize, state.bookmarkFontColor);
+        applyBookmarkMinWidthSetting(state.bookmarkMinWidth);
+
+        if (callback) callback();
+    });
+}


### PR DESCRIPTION
## Summary
- move settings logic into new `settings-handlers` module
- move bookmark rendering into `bookmark-renderer`
- update main script to consume the new submodules

## Testing
- `npm test` *(fails: ReferenceError: jest is not defined)*
- `npm run lint` *(fails: describe is not defined, jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c4384ca4ac832a987769b10d8efec9