### PR TITLE
Allow zero values for customizable settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/js/script.js
+++ b/js/script.js
@@ -15,7 +15,8 @@ import {
     applyIconSpacingSetting,
     applyBookmarkMinWidthSetting,
     applyIconGapSetting,
-    applyBookmarkFontSettings
+    applyBookmarkFontSettings,
+    applyBackgroundFilter
 } from './settings-handlers.js';
 import { renderBookmarks } from './bookmark-renderer.js';
 
@@ -45,6 +46,8 @@ document.addEventListener('DOMContentLoaded', function() {
         bookmarkFontSize: 14,
         bookmarkFontColor: '#333333',
         bookmarkMinWidth: 100,
+        filterColor: '#000000',
+        filterOpacity: 0.3,
         themePreset: 'light'
     };
 
@@ -103,7 +106,7 @@ document.addEventListener('DOMContentLoaded', function() {
     chrome.storage.onChanged.addListener((changes, area) => {
         if (area === 'local' && changes.extensionSettings) {
             const newSettings = changes.extensionSettings.newValue || {};
-            if (newSettings.iconSize && newSettings.iconSize !== settingsState.iconSize) {
+            if (newSettings.iconSize !== undefined && newSettings.iconSize !== settingsState.iconSize) {
                 settingsState.iconSize = newSettings.iconSize;
                 applyIconSizeSetting(settingsState.iconSize);
             }
@@ -140,6 +143,13 @@ document.addEventListener('DOMContentLoaded', function() {
                 applyBookmarkMinWidthSetting(settingsState.bookmarkMinWidth);
             }
 
+            if (newSettings.filterColor && newSettings.filterColor !== settingsState.filterColor) {
+                settingsState.filterColor = newSettings.filterColor;
+            }
+            if (newSettings.filterOpacity !== undefined && newSettings.filterOpacity !== settingsState.filterOpacity) {
+                settingsState.filterOpacity = newSettings.filterOpacity;
+            }
+
             if (newSettings.themePreset && newSettings.themePreset !== settingsState.themePreset) {
                 settingsState.themePreset = newSettings.themePreset;
                 applyTheme(settingsState.themePreset);
@@ -151,6 +161,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 settingsState.bookmarkFontSize,
                 settingsState.bookmarkFontColor
             );
+            applyBackgroundFilter(settingsState.filterColor, settingsState.filterOpacity);
         }
     });
 });

--- a/js/settings-handlers.js
+++ b/js/settings-handlers.js
@@ -2,7 +2,11 @@ export function applyIconSizeSetting(size) {
     document.documentElement.style.setProperty('--icon-size', `${size}px`);
     document.querySelectorAll('.bookmark-favicon').forEach(img => {
         if (img.dataset.url) {
-            img.src = `https://www.google.com/s2/favicons?domain=${img.dataset.url}&sz=${size}`;
+            if (size > 0) {
+                img.src = `https://www.google.com/s2/favicons?domain=${img.dataset.url}&sz=${size}`;
+            } else {
+                img.src = '';
+            }
         }
     });
 }
@@ -31,10 +35,20 @@ export function applyBookmarkFontSettings(fontFamily, fontSize, fontColor) {
     document.documentElement.style.setProperty('--bookmark-font-color', fontColor);
 }
 
+export function applyBackgroundFilter(color, opacity) {
+    const filter = document.getElementById('background-filter');
+    if (filter) {
+        const r = parseInt(color.slice(1, 3), 16);
+        const g = parseInt(color.slice(3, 5), 16);
+        const b = parseInt(color.slice(5, 7), 16);
+        filter.style.backgroundColor = `rgba(${r}, ${g}, ${b}, ${opacity})`;
+    }
+}
+
 export function loadSettings(state, callback) {
     chrome.storage.local.get(['extensionSettings'], result => {
         const settings = result.extensionSettings || {};
-        if (settings.iconSize) {
+        if (settings.iconSize !== undefined) {
             state.iconSize = settings.iconSize;
         }
         if (settings.iconBorderRadius !== undefined) {
@@ -69,12 +83,20 @@ export function loadSettings(state, callback) {
             state.bookmarkMinWidth = settings.bookmarkMinWidth;
         }
 
+        if (settings.filterColor) {
+            state.filterColor = settings.filterColor;
+        }
+        if (settings.filterOpacity !== undefined) {
+            state.filterOpacity = settings.filterOpacity;
+        }
+
         applyIconSizeSetting(state.iconSize);
         applyIconAppearance(state.iconBorderRadius, state.iconBorderColor, state.iconBgColor);
         applyIconSpacingSetting(state.iconSpacing);
         applyIconGapSetting(state.iconGap);
         applyBookmarkFontSettings(state.bookmarkFontFamily, state.bookmarkFontSize, state.bookmarkFontColor);
         applyBookmarkMinWidthSetting(state.bookmarkMinWidth);
+        applyBackgroundFilter(state.filterColor, state.filterOpacity);
 
         if (callback) callback();
     });

--- a/js/settings.js
+++ b/js/settings.js
@@ -121,7 +121,9 @@ document.addEventListener('DOMContentLoaded', function() {
     // Atualizar displays dos valores
     function updateFrequencyDisplay(value) {
         const hours = parseFloat(value);
-        if (hours === 1) {
+        if (hours === 0) {
+            wallpaperFrequencyValue.textContent = "0 horas";
+        } else if (hours === 1) {
             wallpaperFrequencyValue.textContent = "1 hora";
         } else if (hours < 1) {
             wallpaperFrequencyValue.textContent = `${hours * 60} minutos`;

--- a/settings.html
+++ b/settings.html
@@ -103,7 +103,7 @@
             </div>
             <div class="setting-item">
                 <label for="wallpaper-frequency">Frequência de Troca (horas):</label>
-                <input type="range" id="wallpaper-frequency" min="0.5" max="24" step="0.5" value="1">
+                <input type="range" id="wallpaper-frequency" min="0" max="24" step="0.5" value="1">
                 <span id="wallpaper-frequency-value">1 hora</span>
             </div>
             <div class="setting-item">
@@ -121,7 +121,7 @@
             <h2>Bookmarks</h2>
             <div class="setting-item">
                 <label for="icon-size">Tamanho dos Ícones:</label>
-                <input type="range" id="icon-size" min="16" max="64" step="4" value="32">
+                <input type="range" id="icon-size" min="0" max="64" step="4" value="32">
                 <span id="icon-size-value">32px</span>
             </div>
             <div class="setting-item">
@@ -170,7 +170,7 @@
             </div>
             <div class="setting-item">
                 <label for="bookmark-font-size">Tamanho da Fonte:</label>
-                <input type="number" id="bookmark-font-size" min="10" max="30" value="14">
+                <input type="number" id="bookmark-font-size" min="0" max="30" value="14">
                 <span id="bookmark-font-size-value">14px</span>
             </div>
             <div class="setting-item">


### PR DESCRIPTION
## Summary
- Permit 0 as a valid value for sliders like icon size, font size, wallpaper frequency, and others
- Handle 0-sized icons and fonts without breaking layout and update displays to show 0px/0%
- Add background filter application so opacity 0 fully disables the overlay

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5adce6154832a9f41b97aca1db50e